### PR TITLE
Bug fix: catch when the graph API token has expired, to get a new one

### DIFF
--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -16,7 +16,7 @@ function Get-PrincipalMap {
 function Connect-AADUser {
     $ConnectionTest = try{ [Microsoft.Open.Azure.AD.CommonLibrary.AzureSession]::AccessTokens['AccessToken']}
     catch{"Error"}
-    If($ConnectionTest -eq 'Error'){ 
+    If($ConnectionTest -eq 'Error' -or $null -eq $ConnectionTest){ 
     $context = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile.DefaultContext
     $aadToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.windows.net").AccessToken
     Connect-AzureAD -AadAccessToken $aadToken -AccountId $context.Account.Id -TenantId $context.tenant.id}


### PR DESCRIPTION
Scanning my organisations Azure estate took around an hour, and during that time the graph token expired and the script started failing.

Typically this call to `AccessTokens` would return a token or an error, but once the token has expired, it returns a null.
```
[Microsoft.Open.Azure.AD.CommonLibrary.AzureSession]::AccessTokens['AccessToken']
```
Modifying this line
```
If($ConnectionTest -eq 'Error' -or $null -eq $ConnectionTest){ 
```
to catch the null, causes the script to obtain a new token when it's next run.