### PR TITLE
Reduce memory requirements when writing JSON files for large domains

### DIFF
--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -480,7 +480,7 @@ function Invoke-AzureHound {
         $null = $Coll.Add($AzureDeviceOwner)
     }
     New-Output -Coll $Coll -Type "devices" -Directory $OutputDirectory
-    
+ 
     # Enumerate group owners
     $Coll = New-Object System.Collections.ArrayList
     Write-Info "Checking if groups object is already built..."
@@ -797,7 +797,7 @@ function Invoke-AzureHound {
         }
     }
     New-Output -Coll $Coll -Type "kvpermissions" -Directory $OutputDirectory
-    
+
     <#$Coll = @()
     #KeyVault access policies
     $AADSubscriptions | ForEach-Object {
@@ -903,7 +903,7 @@ function Invoke-AzureHound {
     }
     New-Output -Coll $Coll -Type "kvaccesspolicies" -Directory $OutputDirectory
     #>
-    
+
     # Abusable AZ Admin Roles
     Write-Info "Beginning abusable Azure Admin role logic"
     Write-Info "Building initial admin role mapping object"
@@ -1471,12 +1471,10 @@ function Invoke-AzureHound {
         }
     }
     New-Output -Coll $Coll -Type "cloudappadmins" -Directory $OutputDirectory
-	Write-Info "Done processing Cloud Application Admins"
+    Write-Info "Done processing Cloud Application Admins"
 
     # Zip then delete output JSON files
     Write-Host "Compressing files"
-        $jsonpath = $OutputDirectory.Path + '\' + "*.json"
-        $destinationpath = $OutputDirectory.Path + '\' + "$name.zip"       
     $name = $date + "-azurecollection"
     $jsonpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$date-*.json"
     $destinationpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$name.zip"

--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -77,6 +77,7 @@ function New-Output($Coll, $Type, $Directory) {
             $end = (($n+1)*$chunksize)-1
             $chunkarray += ,@($coll[$start..$end])
         }
+        $Stream.Flush()
         $Count = $chunkarray.Count
 
         $chunkcounter = 1
@@ -91,12 +92,13 @@ function New-Output($Coll, $Type, $Directory) {
             } Else {
                 $Stream.WriteLine("")
             }
+            $Stream.Flush()
             $chunkcounter += 1
         }
-        $stream.WriteLine("`t]")
-        $stream.WriteLine("}")
+        $Stream.WriteLine("`t]")
+        $Stream.WriteLine("}")
     } finally {
-        $stream.close()
+        $Stream.close()
     }
 }
 

--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -1473,21 +1473,24 @@ function Invoke-AzureHound {
     New-Output -Coll $Coll -Type "cloudappadmins" -Directory $OutputDirectory
 	Write-Info "Done processing Cloud Application Admins"
 
+    # Zip then delete output JSON files
     Write-Host "Compressing files"
-    $location = Get-Location
-    If($OutputDirectory.path -eq $location.path){
-        $name = $date + "-azurecollection"
         $jsonpath = $OutputDirectory.Path + '\' + "*.json"
         $destinationpath = $OutputDirectory.Path + '\' + "$name.zip"       
+    $name = $date + "-azurecollection"
+    $jsonpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$date-*.json"
+    $destinationpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$name.zip"
+    
+    $error.Clear()
+    try{
         Compress-Archive $jsonpath -DestinationPath $destinationpath
-        rm $jsonpath
     }
-    else{
-        $name = $date + "-azurecollection"
-        $jsonpath = $OutputDirectory + '\' + "*.json"
-        $destinationpath = $OutputDirectory + '\' + "$name.zip"
-        Compress-Archive $jsonpath -DestinationPath $destinationpath
-        rm $jsonpath
+    finally {
+        # Empty as powershell needs at least a catch or finally, but don't use either.
     }
-    Write-Host "Done! Drag and drop the zip into the BloodHound GUI to import data."
+    if (!$error) {
+        rm $jsonpath
+        Write-Host "Zip file created: $destinationpath"
+        Write-Host "Done! Drag and drop the zip into the BloodHound GUI to import data."
+    }
 }

--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -1473,24 +1473,21 @@ function Invoke-AzureHound {
     New-Output -Coll $Coll -Type "cloudappadmins" -Directory $OutputDirectory
 	Write-Info "Done processing Cloud Application Admins"
 
-    # Zip then delete output JSON files
     Write-Host "Compressing files"
+    $location = Get-Location
+    If($OutputDirectory.path -eq $location.path){
+        $name = $date + "-azurecollection"
         $jsonpath = $OutputDirectory.Path + '\' + "*.json"
         $destinationpath = $OutputDirectory.Path + '\' + "$name.zip"       
-    $name = $date + "-azurecollection"
-    $jsonpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$date-*.json"
-    $destinationpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$name.zip"
-    
-    $error.Clear()
-    try{
         Compress-Archive $jsonpath -DestinationPath $destinationpath
-    }
-    finally {
-        # Empty as powershell needs at least a catch or finally, but don't use either.
-    }
-    if (!$error) {
         rm $jsonpath
-        Write-Host "Zip file created: $destinationpath"
-        Write-Host "Done! Drag and drop the zip into the BloodHound GUI to import data."
     }
+    else{
+        $name = $date + "-azurecollection"
+        $jsonpath = $OutputDirectory + '\' + "*.json"
+        $destinationpath = $OutputDirectory + '\' + "$name.zip"
+        Compress-Archive $jsonpath -DestinationPath $destinationpath
+        rm $jsonpath
+    }
+    Write-Host "Done! Drag and drop the zip into the BloodHound GUI to import data."
 }

--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -66,6 +66,7 @@ function New-Output($Coll, $Type, $Directory) {
 
         # Write data JSON
         $Stream.WriteLine("`t""data"": [")
+        $Stream.Flush()
 
         $chunksize = 250
         $chunkarray = @()
@@ -77,7 +78,6 @@ function New-Output($Coll, $Type, $Directory) {
             $end = (($n+1)*$chunksize)-1
             $chunkarray += ,@($coll[$start..$end])
         }
-        $Stream.Flush()
         $Count = $chunkarray.Count
 
         $chunkcounter = 1

--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -480,7 +480,7 @@ function Invoke-AzureHound {
         $null = $Coll.Add($AzureDeviceOwner)
     }
     New-Output -Coll $Coll -Type "devices" -Directory $OutputDirectory
- 
+    
     # Enumerate group owners
     $Coll = New-Object System.Collections.ArrayList
     Write-Info "Checking if groups object is already built..."
@@ -797,7 +797,7 @@ function Invoke-AzureHound {
         }
     }
     New-Output -Coll $Coll -Type "kvpermissions" -Directory $OutputDirectory
-
+    
     <#$Coll = @()
     #KeyVault access policies
     $AADSubscriptions | ForEach-Object {
@@ -903,7 +903,7 @@ function Invoke-AzureHound {
     }
     New-Output -Coll $Coll -Type "kvaccesspolicies" -Directory $OutputDirectory
     #>
-
+    
     # Abusable AZ Admin Roles
     Write-Info "Beginning abusable Azure Admin role logic"
     Write-Info "Building initial admin role mapping object"
@@ -1471,10 +1471,12 @@ function Invoke-AzureHound {
         }
     }
     New-Output -Coll $Coll -Type "cloudappadmins" -Directory $OutputDirectory
-    Write-Info "Done processing Cloud Application Admins"
+	Write-Info "Done processing Cloud Application Admins"
 
     # Zip then delete output JSON files
     Write-Host "Compressing files"
+        $jsonpath = $OutputDirectory.Path + '\' + "*.json"
+        $destinationpath = $OutputDirectory.Path + '\' + "$name.zip"       
     $name = $date + "-azurecollection"
     $jsonpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$date-*.json"
     $destinationpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$name.zip"


### PR DESCRIPTION
In Issue #5 some people are having a problem with the amount of memory being consumed when working with very large domains exhausting their available memory. I have been having this problem too on a domain with about 200k users and a machine with 48GB of memory. This issue partly seems to be due to the Powershell ConvertTo-Json cmdlet consuming vast amounts of memory.

This pull request writes the JSON output as a stream and calls the ConvertTo-Json on chunks of items of 250 at a time. This considerably reduces the memory consumption, although it is still high.