### PR TITLE
Fix a problem where JSON files would be deleted even if zip creation …

### DIFF
--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -1432,19 +1432,26 @@ function Invoke-AzureHound {
 
     Write-Host "Compressing files"
     $location = Get-Location
+    $name = $date + "-azurecollection"
     If($OutputDirectory.path -eq $location.path){
-        $name = $date + "-azurecollection"
-        $jsonpath = $OutputDirectory.Path + '\' + "*.json"
-        $destinationpath = $OutputDirectory.Path + '\' + "$name.zip"       
-        Compress-Archive $jsonpath -DestinationPath $destinationpath
-        rm $jsonpath
+        $jsonpath = $OutputDirectory.Path + [IO.Path]::DirectorySeparatorChar + "$date-*.json"
+        $destinationpath = $OutputDirectory.Path + [IO.Path]::DirectorySeparatorChar + "$name.zip"
     }
     else{
-        $name = $date + "-azurecollection"
-        $jsonpath = $OutputDirectory + '\' + "*.json"
-        $destinationpath = $OutputDirectory + '\' + "$name.zip"
-        Compress-Archive $jsonpath -DestinationPath $destinationpath
-        rm $jsonpath
+        $jsonpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$date-*.json"
+        $destinationpath = $OutputDirectory + [IO.Path]::DirectorySeparatorChar + "$name.zip"
     }
-    Write-Host "Done! Drag and drop the zip into the BloodHound GUI to import data."
+
+    $error.Clear()
+    try {
+        Compress-Archive $jsonpath -DestinationPath $destinationpath
+    }
+    catch {
+        Write-Host "Zip file creation failed, JSON files may still be importable."
+    }
+    if (!$error) {
+        Write-Host "Zip file created: $destinationpath"
+        rm $jsonpath
+        Write-Host "Done! Drag and drop the zip into the BloodHound GUI to import data."
+    }
 }


### PR DESCRIPTION
Proposed fix for Issue #10 where JSON files are still deleted even if zipping failed for some reason (like stream was too big or perhaps disk was full). This is a data-loss bug.