### PR TITLE
Fix missing $PWResetRight

### DIFF
--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -1014,6 +1014,7 @@ function Invoke-AzureHound {
                 TargetUserID        = $TargetUser.UserID
                 TargetUserOnPremID  = $TargetUser.UserOnPremID
             }
+	    $PWResetRight
         }
             
         ForEach ($TargetUser in $UsersWithoutRoles) {

--- a/AzureHound.ps1
+++ b/AzureHound.ps1
@@ -1014,7 +1014,7 @@ function Invoke-AzureHound {
                 TargetUserID        = $TargetUser.UserID
                 TargetUserOnPremID  = $TargetUser.UserOnPremID
             }
-	    $PWResetRight
+            $PWResetRight
         }
             
         ForEach ($TargetUser in $UsersWithoutRoles) {


### PR DESCRIPTION
`$PWResetRight` wasn't returned for **Privileged Authentication Admin** roles for users with roles. With this missing statement, links like `"Privileged Authentication Admin"-[:AzResetPassword]->"Global Admin"` were missing.